### PR TITLE
Added MODVertexBuffera756f2f9

### DIFF
--- a/model.py
+++ b/model.py
@@ -226,8 +226,27 @@ class MODVertexBuffer5e7f202d:
             ReadHalfFloat(headerref.fl)
             ReadHalfFloat(headerref.fl)
             ReadLong(headerref.fl)
+class MODVertexBufferd829702c:
+    def __init__(self,headerref,vertexcount):
+        print("MODVertexBufferd829702c %d" % vertexcount)
+        self.vertarray   = []
+        self.headerref   = headerref
+        self.vertexcount = vertexcount
+        for i in range(0,vertexcount):
+            if headerref.bendian:
+                self.vertarray.append([ReadBEFloat(headerref.fl),ReadBEFloat(headerref.fl),ReadBEFloat(headerref.fl)])
+            else:
+                self.vertarray.append([ReadFloat(headerref.fl),ReadFloat(headerref.fl),ReadFloat(headerref.fl)])
+            Read8s(headerref.fl)
+            Read8s(headerref.fl)
+            Read8s(headerref.fl)
+            ReadByte(headerref.fl)
+            ReadLong(headerref.fl)
+            ReadHalfFloat(headerref.fl)
+            ReadHalfFloat(headerref.fl)
 MODVertexBuffera5104ca0 = MODVertexBuffer5e7f202d
 MODVertexBufferf637401c = MODVertexBufferf06033f
+MODVertexBuffera756f2f9 = MODVertexBufferd829702c
 
 
 pos = {}


### PR DESCRIPTION
I wanted to import some MHW models into Blender, but the one I tried gave an error so I figured I could add it myself and sorta got it to work by adding an extra VertexBuffer:

![screen](https://user-images.githubusercontent.com/839653/45363287-66acd900-b5d7-11e8-9640-2322a06f4584.jpg)

There might be mistakes in the code, but I wanted to thank you for starting this and I already had the changes so I figured I could make a PR.